### PR TITLE
Made KAT medical loadout more useful.

### DIFF
--- a/c/loadouts/common.hpp
+++ b/c/loadouts/common.hpp
@@ -7,7 +7,7 @@
 
 // GEAR
 #define BASE_MEDICAL "ACE_elasticBandage:2","ACE_packingBandage:2","ACE_tourniquet:2","ACE_splint"
-#define MEDIC_MEDICAL "ACE_packingBandage:20","ACE_elasticBandage:20","ACE_splint:8","ACE_tourniquet:6","ACE_plasmaIV_500:4","kat_X_AED","kat_accuvac","kat_Pulseoximeter","kat_larynx","kat_aatKit","kat_guedel:5","kat_stethoscope","kat_chestSeal:2","kat_IO_FAST:2","kat_IV_16:6","ACE_morphine:8","ACE_epinephrine:8","ACE_adenosine:8","kat_Carbonate:4","kat_Painkiller:4","kat_nitroglycerin:4","kat_norepinephrine:4","kat_phenylephrine:4","kat_TXA:4","kat_atropine:4","kat_amiodarone:4","kat_naloxone:4","kat_lidocaine:4"
+#define MEDIC_MEDICAL "ACE_packingBandage:20","ACE_elasticBandage:20","ACE_splint:8","ACE_tourniquet:6","ACE_plasmaIV_500:4","kat_accuvac","kat_Pulseoximeter","kat_larynx:2","kat_aatKit:10","kat_guedel:5","kat_stethoscope","kat_chestSeal:10","kat_IO_FAST:5","kat_IV_16:15","ACE_morphine:8","ACE_epinephrine:8","ACE_adenosine:8","kat_Carbonate","kat_Painkiller","kat_nitroglycerin:4","kat_norepinephrine:4","kat_phenylephrine:4","kat_TXA:8","kat_atropine:4","kat_amiodarone:4","kat_naloxone","kat_lidocaine:4"
 #define BASE_TOOLS "ACE_MapTools","ACE_IR_Strobe_item:2","ACE_Flashlight_XL50","ACE_SpraypaintRed","ACE_CableTie:2"
 #define BASE_LEADER_TOOLS "ACE_personalAidKit","ACE_Fortify"
 #define BASE_LINKED "ItemMap","ItemCompass","ItemWatch"


### PR DESCRIPTION
Removed AED-X to reduce base weight. Can be added back by MM, or found in medical facilities. 

Increased IV and IO count.  IV from 6 ->15. IO 2 -> 5. 

Increased AAT and Chest seal count.  AAT 1 -> 10.  Chest seal 2 ->10

doubled TXA count to encourage its use 

Reduced Ammonium and painkiller count from 4->1 as each 1 = a box of 10. 

Reduced narcan count to 1, hopefully nobody OD's someone negligently. However, left one due to chance of negative effects needing to be removed for other reasons. More can be picked up from medical facilities / vics

These should make medics last longer before needing to pop CCP to deal with the next KAT wound. As well as enable them to be slightly more liberal with fluids and drugs.